### PR TITLE
Fix broken RSS link at top

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -33,7 +33,7 @@ weight = 5
 
 [[main]]
 name = ":newspaper_roll: RSS"
-pageRef = "https://gilbertsanchez.com/index.xml"
+url = "/index.xml"
 identifier = "zNh9Tjq8MD"
 weight = 6
 
@@ -72,6 +72,6 @@ weight = 5
 
 [[footer]]
 name = ":newspaper_roll: RSS"
-pageRef = "https://gilbertsanchez.com/index.xml"
+url = "/index.xml"
 identifier = "zNh9Tjq8MD"
 weight = 6


### PR DESCRIPTION
Changed RSS menu link from pageRef to url parameter. The pageRef parameter is for internal Hugo pages, while url is for external URLs and absolute paths. This fixes the broken RSS link in both the main and footer menus.