### PR TITLE
fix(seo): consolidate duplicate JSON-LD to a single emitter per page

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -143,9 +143,6 @@
   {{/* Social */}}
   {{- partial "opengraph.html" . -}}
 
-  {{/* Schema */}}
-  {{ partial "schema.html" . }}
-
   {{/* Me */}}
   {{ with .Site.Params.Author.name }}
     <meta name="author" content="{{ . }}">

--- a/layouts/partials/struct-data.html
+++ b/layouts/partials/struct-data.html
@@ -11,8 +11,16 @@
 {
     "@context": "https://schema.org",
     "@type": "WebSite",
+    "@id": "{{ .Site.BaseURL }}",
     "name": "{{ .Site.Title | plainify | safeJS }}",
-    "url": "{{ .Site.BaseURL }}"
+    {{- with .Site.LanguageCode }}
+    "inLanguage": "{{ . }}",
+    {{- end }}
+    "url": "{{ .Site.BaseURL }}",
+    "publisher": {
+        "@type": "Person",
+        "name": "{{ $authorName | safeJS }}"
+    }
 }
 </script>
 {{- end }}
@@ -64,6 +72,9 @@
 {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
+    {{- with .Site.LanguageCode }}
+    "inLanguage": "{{ . }}",
+    {{- end }}
     "headline": "{{ .Title | plainify | safeJS }}",
     "description": "{{ with .Description }}{{ . | plainify | safeJS }}{{ else }}{{ with .Summary }}{{ . | plainify | truncate 160 | safeJS }}{{ end }}{{ end }}",
     "wordCount": {{ .WordCount }},
@@ -73,6 +84,10 @@
     "datePublished": "{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}",
     "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}",
     "url": "{{ .Permalink }}",
+    "mainEntityOfPage": "{{ .Permalink }}",
+    {{- with .Params.tags }}
+    "keywords": "{{ delimit . ", " | safeJS }}",
+    {{- end }}
     "image": [{{ range $i, $url := $imageUrls }}{{ if $i }}, {{ end }}"{{ $url | safeJS }}"{{ end }}],
     "author": [{
         "@type": "Person",


### PR DESCRIPTION
## Problem
Every page emitted overlapping JSON-LD because two partials ran: the theme
`schema.html` (called from the `head.html` override) and the custom
`struct-data.html`. Result: 2x `WebSite` on the home page, and an overlapping
`Article` (theme) + `BlogPosting` (custom) on single pages. Pre-existing issue,
surfaced while adding project SEO.

## Change
- Remove the `{{ partial "schema.html" . }}` call from `layouts/partials/head.html`
  so `struct-data.html` is the sole structured-data emitter.
- Enrich the custom partial so no theme fields regress:
  - `WebSite`: add `@id`, `inLanguage`, `publisher`.
  - `BlogPosting`: add `inLanguage`, `mainEntityOfPage` (canonical URL form, not
    the theme's invalid `"true"`), `keywords` (comma-joined tags).
- `BreadcrumbList` and the projects `CollectionPage`/`ItemList` (35 items) are
  unchanged.

## Verification
`./bin/hugo/hugo` builds clean (exit 0). Parsed `application/ld+json` from
representative outputs; every block is valid JSON with no duplicate `@type`:
- home: single `WebSite`
- post: `BreadcrumbList` + `BlogPosting` (no stray `Article`)
- /projects/: `BreadcrumbList` + `CollectionPage`/`ItemList` (35)
- /posts/ and a tag page: `BreadcrumbList` only